### PR TITLE
Move endpoint hardcoded do backend para um .env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,8 +2,9 @@
 # Utilize esse arquivo como base.
 
 # Ativa ou desativa o modo de demonstração.
+# true ou false
 # O modo de demonstração permite a exeução do front-end sem um back-end configurado.
-VUE_APP_DEMO_MODE = false
+VUE_APP_DEMO_MODE =
 
 # Base do endpoint da API
-VUE_APP_API_BASE_ENDPOINT = https://blooming-springs-31144.herokuapp.com/Api/
+VUE_APP_API_BASE_ENDPOINT =

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,9 @@
+# Você deve criar um arquivo .env (para desenvolvimento) e um arquivo .env.production (para produção).
+# Utilize esse arquivo como base.
+
+# Ativa ou desativa o modo de demonstração.
+# O modo de demonstração permite a exeução do front-end sem um back-end configurado.
+VUE_APP_DEMO_MODE = false
+
+# Base do endpoint da API
+VUE_APP_API_BASE_ENDPOINT = https://blooming-springs-31144.herokuapp.com/Api/

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@
 node_modules
 /dist
 
+.env
+.env.production
+
 # local env files
 .env.local
 .env.*.local

--- a/src/services/ConfigServices.js
+++ b/src/services/ConfigServices.js
@@ -1,6 +1,6 @@
 import axios from 'axios';
 
-const urlbase = 'https://blooming-springs-31144.herokuapp.com/Api/';
+const urlbase = process.env.VUE_APP_API_BASE_ENDPOINT;
 let header = "";
 
 function setTokenHeader() {


### PR DESCRIPTION
- Adiciona um arquivo .env.example com duas variáveis: uma do "demo mode", a ser implementado no futuro que não vai obter dados da API e outra com o endpoint da API.