### PR TITLE
yt-lazyload: implementa lazyload do vídeo promocional (hardcoded).

### DIFF
--- a/src/components/content/Midia.vue
+++ b/src/components/content/Midia.vue
@@ -8,10 +8,17 @@
                 </div>
                 <div class="col-12">
                     <div class="d-flex justify-content-center">
-                        <iframe class="video" width="560" height="315"
-                                title="Vídeo do Youtube"
-                                :src="'https://www.youtube.com/embed/' + secao.st_video"
-                                allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"></iframe>
+                      <iframe
+                          width="560"
+                          height="315"
+                          :src="'https://www.youtube.com/embed/' + secao.st_video + '&autoplay=1'"
+                          srcdoc="<style>*{padding:0;margin:0;overflow:hidden}html,body{height:100%}img,span{position:absolute;width:100%;top:0;bottom:0;margin:auto}
+                          span{height:1.5em;text-align:center;font:48px/1.5 sans-serif;color:white;text-shadow:0 0 0.5em black}</style>
+                          <a href=https://www.youtube.com/embed/qBsfiDiZjV4?autoplay=1><img src=https://img.youtube.com/vi/qBsfiDiZjV4/hqdefault.jpg alt='Video The Dark Knight Rises: What Went Wrong? – Wisecrack Edition'><span>▶</span></a>"
+                          allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
+                          allowfullscreen
+                          title="Vídeo do Youtube"
+                      ></iframe>
                     </div>
                 </div>
             </div>
@@ -25,7 +32,7 @@
                     ></Secao>
 
                     <div></div>
-                    <Depoimento v-for="(item, indice) in comentarios"
+                    <Depoimento v-for="(item) in comentarios"
                                 v-bind:depoimento="item.st_comentario"
                                 v-bind:autor="item.st_autor"
                                 v-bind:imagens="item.imagens"
@@ -45,10 +52,11 @@
     import Depoimento from "../itens/Testimonial";
     import ComentarioApi from "@/services/ComentarioApi";
     import SecaoApi from "@/services/SecaoApi";
+    import VueLazyYoutubeVideo from 'vue-lazy-youtube-video';
 
     export default {
         name: 'Midia',
-        components: {Depoimento, Secao},
+        components: {Depoimento, Secao, VueLazyYoutubeVideo},
 
         created() {
             ComentarioApi.getAllComentarios(retorno => {
@@ -72,6 +80,8 @@
 </script>
 
 <style lang="scss">
+
+    @import 'vue-lazy-youtube-video/dist/style.css';
 
     .depoimentos {
         background: $bg-light;

--- a/src/components/content/Midia.vue
+++ b/src/components/content/Midia.vue
@@ -52,11 +52,10 @@
     import Depoimento from "../itens/Testimonial";
     import ComentarioApi from "@/services/ComentarioApi";
     import SecaoApi from "@/services/SecaoApi";
-    import VueLazyYoutubeVideo from 'vue-lazy-youtube-video';
 
     export default {
         name: 'Midia',
-        components: {Depoimento, Secao, VueLazyYoutubeVideo},
+        components: {Depoimento, Secao},
 
         created() {
             ComentarioApi.getAllComentarios(retorno => {
@@ -80,8 +79,6 @@
 </script>
 
 <style lang="scss">
-
-    @import 'vue-lazy-youtube-video/dist/style.css';
 
     .depoimentos {
         background: $bg-light;


### PR DESCRIPTION
O pré-carregamento do Youtube é uma das coisas que mais afetavam a performance da página inicial. Essa implementação é beseada na estratégia explicada aqui: https://css-tricks.com/lazy-load-embedded-youtube-videos/. Basicamente, é carregada uma imagem, sem baixar o conteúdo para renderizar o iframe e ao clicar, o conteúdo é baixado.

Reduziu bem a quantidade de JS baixada na página apenas pelo uso do embed do vídeo no Youtube.

A nível de comparação, o impacto nas notas do pagespeed insights:
**Antes**
Mobile: 27
Desktop: 51

**Com a implementação do lazyload**
Mobile: 58
Desktop: 97