### PR TITLE
google-maps-lazy-loading: implementa lazy loading do mapa 

### DIFF
--- a/src/components/content/Locale.vue
+++ b/src/components/content/Locale.vue
@@ -21,7 +21,11 @@
                 </div>
                 <div class="col-sm-12 col-md-6 mapa">
                     <iframe src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d3752.8677220905865!2d-44.61226498529925!3d-19.845549140813137!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0xa73c0a76f18ba9%3A0x18a18e6f43c7f071!2sFaculdade+de+Par%C3%A1+de+Minas+-+FAPAM!5e0!3m2!1spt-BR!2sbr!4v1557353297848!5m2!1spt-BR!2sbr"
-                            width="100%" height="450" style="border:0" allowfullscreen></iframe>
+                            width="100%"
+                            height="450"
+                            loading="lazy"
+                            style="border:0" allowfullscreen>
+                    </iframe>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
Seguindo uma otimização semelhante à implementada em #211, implementa lazy-loading no iframe com o mapa do Google. 